### PR TITLE
Including Http Status 103 defined in RFC8297

### DIFF
--- a/contents/codes/103.md
+++ b/contents/codes/103.md
@@ -1,0 +1,23 @@
+---
+set: 1
+code: 103
+title: Early Hints
+references:
+    "C# HTTP Status Enum": "HttpStatusCode.EarlyHints"
+---
+
+The 103 (Early Hints) informational status code indicates to the client that the server is likely to send a final response with the header fields included in the informational response.
+
+Typically, a server will include the header fields sent in a 103 (Early Hints) response in the final response as well.  However, there might be cases when this is not desirable, such as when the server learns that the header fields in the 103 (Early Hints) response are not correct before the final response is sent.
+
+A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while waiting for the final response.  For example, a client might recognize a Link header field value containing the relation type "preload" and start fetching the target resource.  However, these header fields only provide hints to the client; they do not replace the header fields on the final response.
+
+Aside from performance optimizations, such evaluation of the 103 (Early Hints) response's header fields MUST NOT affect how the final response is processed.  A client MUST NOT interpret the 103 (Early Hints) response header fields as if they applied to the informational response itself (e.g., as metadata about the 103 (Early Hints) response).
+
+A server MAY use a 103 (Early Hints) response to indicate only some of the header fields that are expected to be found in the final response.  A client SHOULD NOT interpret the nonexistence of a header field in a 103 (Early Hints) response as a speculation that the header field is unlikely to be part of the final response.
+
+---
+
+* Source: [RFC8297 Section 2][1]
+
+[1]: <https://tools.ietf.org/html/rfc8297#section-2>


### PR DESCRIPTION
Although discussed in #16 back in 2014 as a non-standard, [RCF8297](https://tools.ietf.org/html/rfc8297#section-4) defines HTTP Status Code 103 as a standard in late 2017.

Sources:
https://tools.ietf.org/html/rfc8297
https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
