### PR TITLE
Update Rails symbol syntax for 400 status

### DIFF
--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -3,7 +3,7 @@ set: 4
 code: 400
 title: Bad Request
 references:
-    "Rails HTTP Status Symbol": "bad_request"
+    "Rails HTTP Status Symbol": ":bad_request"
     "Go HTTP Status Constant": "http.StatusBadRequest"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_REQUEST"
     "Python2 HTTP Status Constant": "httplib.BAD_REQUEST"


### PR DESCRIPTION
`:bad_request` is a symbol, and what Rails expects to be passed as status, while `bad_request` would have looked for a method or variable with that name.